### PR TITLE
fix: resolve infinite canonical redirect loop on non-ASCII locales

### DIFF
--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -6,6 +6,10 @@ import {
   locales,
 } from "@/i18n/config";
 
+// Note: `zh-CN` paths intentionally use ASCII (e.g. `/login` instead of
+// `/登录`). next-intl's canonical redirect mis-handles non-ASCII localized
+// paths (the decoded/encoded forms never match), causing an infinite 308
+// loop. The UI language stays Chinese; only the URL paths are ASCII.
 export const pathnames = {
   "/": {
     en: "/",
@@ -36,7 +40,7 @@ export const pathnames = {
     "pt-BR": "/configuracoes",
     id: "/pengaturan",
     hi: "/सेटिंग्स",
-    "zh-CN": "/设置",
+    "zh-CN": "/settings",
     ja: "/設定",
     ko: "/설정",
     tr: "/ayarlar",
@@ -57,7 +61,7 @@ export const pathnames = {
     "pt-BR": "/entrar",
     id: "/masuk",
     hi: "/लॉगिन",
-    "zh-CN": "/登录",
+    "zh-CN": "/login",
     ja: "/ログイン",
     ko: "/로그인",
     tr: "/giriş",
@@ -78,7 +82,7 @@ export const pathnames = {
     "pt-BR": "/cadastro",
     id: "/daftar",
     hi: "/पंजीकरण",
-    "zh-CN": "/注册",
+    "zh-CN": "/register",
     ja: "/登録",
     ko: "/회원가입",
     tr: "/kayıt",
@@ -99,7 +103,7 @@ export const pathnames = {
     "pt-BR": "/teste",
     id: "/uji",
     hi: "/परीक्षण",
-    "zh-CN": "/测试",
+    "zh-CN": "/test",
     ja: "/テスト",
     ko: "/테스트",
     tr: "/test",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -34,6 +34,26 @@ import { routing } from "./i18n/routing";
 type LocaleKey = Locale;
 type RouteKey = ProxyRouteKey;
 
+/**
+ * Compare two pathnames ignoring percent-encoding differences.
+ *
+ * Next.js keeps `request.nextUrl.pathname` percent-encoded
+ * (e.g. `/zh-CN/%E7%99%BB%E5%BD%95`), while `buildRedirectUrl` may produce a
+ * decoded path (e.g. `/zh-CN/登录`). A direct `!==` comparison is therefore
+ * always true for non-ASCII locales, which causes an infinite canonical
+ * redirect loop. Comparing after decoding both sides fixes it.
+ */
+function samePathname(a: string, b: string): boolean {
+  const decode = (p: string): string => {
+    try {
+      return decodeURIComponent(p);
+    } catch {
+      return p; // 非合法编码串，按原样比较
+    }
+  };
+  return decode(a) === decode(b);
+}
+
 export async function proxy(request: NextRequest) {
   const logAuth = logger.withScope("Auth");
   const logSecurity = logger.withScope("Security");
@@ -68,7 +88,7 @@ export async function proxy(request: NextRequest) {
       ? resolvedRest
       : "/";
     const redirectUrl = buildRedirectUrl(request, settingsLocale, targetRest);
-    if (redirectUrl.pathname !== pathname) {
+    if (!samePathname(redirectUrl.pathname, pathname)) {
       const redirectResponse = NextResponse.redirect(redirectUrl);
       attachLocaleCookies(redirectResponse, settingsLocale);
       return secureResponse(redirectResponse);
@@ -112,9 +132,13 @@ export async function proxy(request: NextRequest) {
         requestedLocale,
         canonicalRest,
       );
-      const redirectResponse = NextResponse.redirect(redirectUrl, 308);
-      attachLocaleCookies(redirectResponse, requestedLocale);
-      return secureResponse(redirectResponse);
+      // If the canonical target equals the current path (compared after
+      // decoding), skip the redirect to avoid a 308 loop on non-ASCII locales.
+      if (!samePathname(redirectUrl.pathname, pathname)) {
+        const redirectResponse = NextResponse.redirect(redirectUrl, 308);
+        attachLocaleCookies(redirectResponse, requestedLocale);
+        return secureResponse(redirectResponse);
+      }
     }
   }
 
@@ -280,14 +304,33 @@ function buildLocaleRedirectResponse(
   locale: LocaleKey,
   restPath: string,
 ): NextResponse {
+  // Use the public origin when available (Next middleware redirects require
+  // absolute URLs; see getPublicOrigin).
   const redirectResponse = NextResponse.redirect(
     new URL(
       restPath === "/" ? `/${locale}` : `/${locale}${restPath}`,
-      request.url,
+      getPublicOrigin(request),
     ),
   );
   attachLocaleCookies(redirectResponse, locale);
   return redirectResponse;
+}
+
+function getPublicOrigin(request: NextRequest): string {
+  // Use the explicitly configured external URL when available. Deriving the
+  // origin from `request.url` is unreliable behind a reverse proxy: the
+  // X-Forwarded-Proto header plus the self hostname can yield
+  // `https://localhost:8901`, which does not match the init URL's origin and
+  // makes Next.js proxy the redirect internally (EPROTO against an HTTP port).
+  const authUrl = process.env.BETTER_AUTH_URL;
+  if (authUrl) {
+    try {
+      return new URL(authUrl).origin;
+    } catch {
+      // fall through
+    }
+  }
+  return new URL(request.url).origin;
 }
 
 function buildLoginRedirectResponse(
@@ -296,7 +339,7 @@ function buildLoginRedirectResponse(
 ): NextResponse {
   const redirectUrl = new URL(
     `/${locale}${getLocalizedLoginPath(locale)}`,
-    request.url,
+    getPublicOrigin(request),
   );
   redirectUrl.searchParams.set("next", request.nextUrl.pathname);
   const redirectResponse = NextResponse.redirect(redirectUrl);


### PR DESCRIPTION
## Problem

When the UI locale uses non-ASCII pathnames (e.g. `zh-CN` maps `/login` to `/登录`), the proxy middleware enters an infinite canonical redirect loop:

1. **308 loop**: next-intl's canonical check compares the percent-encoded `request.nextUrl.pathname` (`/zh-CN/%E7%99%BB%E5%BD%95`) against the decoded path produced by `buildRedirectUrl` (`/zh-CN/登录`). They never match, so the middleware keeps redirecting to the same path — the site is unreachable.

2. **EPROTO / 500**: the auth/login redirects build absolute URLs from `request.url`, whose origin can be `https://localhost:8901` behind a reverse proxy (`X-Forwarded-Proto: https` + self hostname). That origin differs from the init URL's origin, so Next.js proxies the redirect internally and fails with `EPROTO` (TLS handshake against the plain-HTTP port), returning 500.

## Changes

- **`src/proxy.ts`**: add `samePathname()` (compares pathnames after `decodeURIComponent`) and use it for the canonical redirect guard — skip the redirect when the target equals the current path.
- **`src/proxy.ts`**: build auth/login redirects from `BETTER_AUTH_URL` when set (`getPublicOrigin()`), falling back to `request.url`'s origin, so the redirect origin matches the public host instead of the loopback address.
- **`src/i18n/routing.ts`**: use ASCII pathnames for the `zh-CN` locale (`/login`, `/register`, `/settings`, `/test`) to avoid next-intl mis-handling non-ASCII localized paths. **The UI language remains Chinese** — only the URL paths change.

## Verification

- `tsc --noEmit` ✅
- `biome check` on changed files ✅
- Tested in a production deployment behind nginx: `/zh-CN/login` returns 200 with the Chinese UI, no redirect loop, no EPROTO errors.