### PR TITLE
fix: use public origin for redirects behind a reverse proxy

### DIFF
--- a/src/lib/proxy/locale-routing.ts
+++ b/src/lib/proxy/locale-routing.ts
@@ -187,8 +187,15 @@ export function buildRedirectUrl(
   request: NextRequest,
   locale: Locale,
   localizedRest: string,
+  baseUrl?: string,
 ): URL {
-  const url = new URL(request.url);
+  // `baseUrl` allows callers to override the origin with a public URL when
+  // running behind a reverse proxy (see getPublicOrigin in proxy.ts).
+  // Deriving the origin from `request.url` is unreliable there: the
+  // X-Forwarded-Proto header plus the self hostname can yield
+  // `https://localhost:8901`, which does not match the init URL's origin and
+  // makes Next.js proxy the redirect internally (EPROTO against an HTTP port).
+  const url = new URL(baseUrl ?? request.url);
   url.pathname =
     localizedRest === "/" ? `/${locale}` : `/${locale}${localizedRest}`;
   url.search = request.nextUrl.search;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -67,7 +67,7 @@ export async function proxy(request: NextRequest) {
     const targetRest = getRouteMatchForPath(settingsLocale, resolvedRest)
       ? resolvedRest
       : "/";
-    const redirectUrl = buildRedirectUrl(request, settingsLocale, targetRest);
+    const redirectUrl = buildRedirectUrl(request, settingsLocale, targetRest, getPublicOrigin(request));
     if (redirectUrl.pathname !== pathname) {
       const redirectResponse = NextResponse.redirect(redirectUrl);
       attachLocaleCookies(redirectResponse, settingsLocale);
@@ -76,7 +76,7 @@ export async function proxy(request: NextRequest) {
   } else if (requestedLocale !== settingsLocale) {
     const requestedRouteMatch = getRouteMatchForPath(requestedLocale, restPath);
     if (!requestedRouteMatch) {
-      const redirectUrl = buildRedirectUrl(request, settingsLocale, "/");
+      const redirectUrl = buildRedirectUrl(request, settingsLocale, "/", getPublicOrigin(request));
       const redirectResponse = NextResponse.redirect(redirectUrl);
       attachLocaleCookies(redirectResponse, settingsLocale);
       return secureResponse(redirectResponse);
@@ -86,14 +86,14 @@ export async function proxy(request: NextRequest) {
       settingsLocale,
       requestedLocale,
     );
-    const redirectUrl = buildRedirectUrl(request, settingsLocale, targetRest);
+    const redirectUrl = buildRedirectUrl(request, settingsLocale, targetRest, getPublicOrigin(request));
     const redirectResponse = NextResponse.redirect(redirectUrl);
     attachLocaleCookies(redirectResponse, settingsLocale);
     return secureResponse(redirectResponse);
   } else {
     const routeMatch = getRouteMatchForPath(requestedLocale, restPath);
     if (!routeMatch) {
-      const redirectUrl = buildRedirectUrl(request, requestedLocale, "/");
+      const redirectUrl = buildRedirectUrl(request, requestedLocale, "/", getPublicOrigin(request));
       const redirectResponse = NextResponse.redirect(redirectUrl);
       attachLocaleCookies(redirectResponse, requestedLocale);
       return secureResponse(redirectResponse);
@@ -111,6 +111,7 @@ export async function proxy(request: NextRequest) {
         request,
         requestedLocale,
         canonicalRest,
+        getPublicOrigin(request),
       );
       const redirectResponse = NextResponse.redirect(redirectUrl, 308);
       attachLocaleCookies(redirectResponse, requestedLocale);
@@ -291,11 +292,28 @@ function buildLocaleRedirectResponse(
   const redirectResponse = NextResponse.redirect(
     new URL(
       restPath === "/" ? `/${locale}` : `/${locale}${restPath}`,
-      request.url,
+      getPublicOrigin(request),
     ),
   );
   attachLocaleCookies(redirectResponse, locale);
   return redirectResponse;
+}
+
+function getPublicOrigin(request: NextRequest): string {
+  // Use the explicitly configured external URL when available. Deriving the
+  // origin from `request.url` is unreliable behind a reverse proxy: the
+  // X-Forwarded-Proto header plus the self hostname can yield
+  // `https://localhost:8901`, which does not match the init URL's origin and
+  // makes Next.js proxy the redirect internally (EPROTO against an HTTP port).
+  const authUrl = process.env.BETTER_AUTH_URL;
+  if (authUrl) {
+    try {
+      return new URL(authUrl).origin;
+    } catch {
+      // fall through
+    }
+  }
+  return new URL(request.url).origin;
 }
 
 function buildLoginRedirectResponse(
@@ -304,7 +322,7 @@ function buildLoginRedirectResponse(
 ): NextResponse {
   const redirectUrl = new URL(
     `/${locale}${getLocalizedLoginPath(locale)}`,
-    request.url,
+    getPublicOrigin(request),
   );
   redirectUrl.searchParams.set("next", request.nextUrl.pathname);
   const redirectResponse = NextResponse.redirect(redirectUrl);

--- a/tests/unit/lib/proxy-locale-routing.test.ts
+++ b/tests/unit/lib/proxy-locale-routing.test.ts
@@ -359,3 +359,57 @@ describe("proxy/locale-routing", () => {
     },
   );
 });
+
+describe("buildRedirectUrl behind a reverse proxy (regression)", () => {
+  it.each([
+    // [baseUrl, expectedOrigin]
+    ["https://releases.monitor.dc-sy.cn", "https://releases.monitor.dc-sy.cn"],
+    [undefined, "https://localhost:8901"],
+  ])(
+    "uses the explicit public baseUrl %s when provided, else falls back to request.url",
+    (baseUrl, expectedOrigin) => {
+      // Simulate a request as seen by the app behind a reverse proxy:
+      // nginx forwards X-Forwarded-Proto: https, so request.url's origin is
+      // reconstructed as https://localhost:<port> (self hostname + forwarded
+      // protocol) instead of the public host.
+      const request = {
+        nextUrl: new URL(
+          "https://localhost:8901/zh-CN/login?next=%2Fzh-CN",
+        ),
+        url: "https://localhost:8901/zh-CN/login?next=%2Fzh-CN",
+      } as unknown as NextRequest;
+
+      const redirect = buildRedirectUrl(
+        request,
+        "zh-CN",
+        "/login",
+        baseUrl,
+      );
+
+      expect(redirect.origin).toBe(expectedOrigin);
+      expect(redirect.pathname).toBe("/zh-CN/login");
+      // Regression: without baseUrl the origin would be https://localhost:8901,
+      // which does not match the init URL's origin (http://127.0.0.1:8901) and
+      // makes Next.js proxy the redirect internally → EPROTO.
+    },
+  );
+
+  it("keeps request search and hash when a public baseUrl is used", () => {
+    const request = {
+      nextUrl: new URL("https://localhost:8901/zh-CN/settings?tab=x#hash"),
+      url: "https://localhost:8901/zh-CN/settings?stale=1#old",
+    } as unknown as NextRequest;
+
+    const redirect = buildRedirectUrl(
+      request,
+      "zh-CN",
+      "/settings",
+      "https://releases.monitor.dc-sy.cn",
+    );
+
+    expect(redirect.origin).toBe("https://releases.monitor.dc-sy.cn");
+    expect(redirect.pathname).toBe("/zh-CN/settings");
+    expect(redirect.search).toBe("?tab=x");
+    expect(redirect.hash).toBe("#hash");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes HTTP 500 (`EPROTO`) for redirects when the app runs behind a reverse proxy that forwards `X-Forwarded-Proto`. Rebased onto `develop` as requested.

## Reproduction

**nginx config** (production, complete):

```nginx
server {
    listen 443 ssl http2;
    server_name releases.monitor.dc-sy.cn;
    location / {
        proxy_pass http://127.0.0.1:8901;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_read_timeout 60s;
        proxy_buffer_size 16k;
        proxy_buffers 4 32k;
        proxy_busy_buffers_size 64k;
    }
}
```

**systemd unit**: `HOSTNAME=127.0.0.1`, `PORT=8901`, `HTTPS=false`, `BETTER_AUTH_URL=https://releases.monitor.dc-sy.cn`.

**Request trace** (against a pristine standalone build with locale `zh-CN`, same headers as nginx sends):

```
$ curl -sL -H "Host: releases.monitor.dc-sy.cn" -H "X-Forwarded-Proto: https" http://127.0.0.1:8901/
→ GET / → 307 → /zh-CN/登录?next=%2Fzh-CN
→ 500

journal: Failed to proxy https://localhost:8901/zh-CN/login?next=%2Fzh-CN
         Error: write EPROTO ... tls_validate_record_header: wrong version number
```

Without `X-Forwarded-Proto` the same request instead loops on 308s (canonical redirect between `/zh-CN/登录` and `/zh-CN/login`).

## Root cause

`buildLoginRedirectResponse`, `buildLocaleRedirectResponse` and `buildRedirectUrl` build absolute URLs from `request.url`. Behind a proxy, Next.js reconstructs `request.url`'s origin from `X-Forwarded-Proto` plus the app's own hostname → `https://localhost:8901`. That origin differs from the init URL's origin (`http://127.0.0.1:8901`), so Next.js decides the redirect target is not relative to the current request and proxies it internally — sending a TLS handshake to a plain-HTTP port → `EPROTO` → 500. This affects any locale (not only non-ASCII ones) whenever the app is behind such a proxy.

## Changes

- `src/proxy.ts`: add `getPublicOrigin(request)` — uses `BETTER_AUTH_URL`'s origin when configured (it already points at the public URL), falls back to `request.url`'s origin.
- Pass the public origin to **all** redirect paths: `buildRedirectUrl(...)` (new optional `baseUrl` parameter), `buildLoginRedirectResponse`, `buildLocaleRedirectResponse`.
- `tests/unit/lib/proxy-locale-routing.test.ts`: regression tests for the reverse-proxy scenario (origin override + preserved search/hash + fallback behavior).

Deliberately **not** changed: localized pathnames (e.g. `zh-CN: /登录`) remain canonical; no encoding-related logic touched — the origin mismatch is the only issue this PR addresses.

## Verification

- `tsc --noEmit` ✅
- `biome check` ✅
- `vitest run tests/unit/lib/proxy-locale-routing.test.ts` → 41 passed ✅
- Full `tests/unit` → 1356 passed / 2 failed (cron scheduler tests; **also fail on pristine develop**, pre-existing)
- Standalone build behind production-like forwarded headers: all four scenarios (with/without `X-Forwarded-Proto`, direct login page visits) now return 200/307 with zero `EPROTO` errors ✅